### PR TITLE
Add --delimiter (-d) option for custom field separators

### DIFF
--- a/src/args.zig
+++ b/src/args.zig
@@ -5,6 +5,7 @@
 pub const Args = struct {
     const params = clap.parseParamsComptime(
         \\    --color <COLOR>       Turn color off and on (on|off|auto)
+        \\-d, --delimiter <CHAR>    Set field delimiter (default ',')
         \\    --theme <THEME>       Select color theme (auto|dark|light)
         \\-n, --row-numbers         Turn on row numbers
         \\-t, --title <STRING>      Add a title to the table
@@ -16,12 +17,20 @@ pub const Args = struct {
 
     // clap parsers
     const parsers = .{
+        .CHAR = parseChar,
         .COLOR = clap.parsers.enumeration(types.Color),
         .FILE = clap.parsers.string,
         .INT = clap.parsers.int(usize, 10),
         .STRING = clap.parsers.string,
         .THEME = clap.parsers.enumeration(types.Theme),
     };
+
+    fn parseChar(input: []const u8) error{InvalidArgument}!u8 {
+        if (input.len == 1) return input[0];
+        // support common names
+        if (std.mem.eql(u8, input, "tab")) return '\t';
+        return error.InvalidArgument;
+    }
 
     // state
     action: ?Action = null,
@@ -83,6 +92,7 @@ pub const Args = struct {
 
         var config: types.Config = .{};
         if (res.args.color) |v| config.color = v;
+        if (res.args.delimiter) |v| config.delimiter = v;
         if (res.args.theme) |v| config.theme = v;
         if (res.args.title) |v| config.title = v;
         if (res.args.width) |v| config.width = v;
@@ -173,6 +183,44 @@ test "parse parses options" {
     try std.testing.expectEqual(80, out.config.width);
     try std.testing.expect(out.config.row_numbers);
     try std.testing.expectEqualStrings("-", out.filename.?);
+}
+
+test "parse parses delimiter option" {
+    var diag: clap.Diagnostic = .{};
+    const out = try Args.parse(std.testing.allocator, &.{
+        "--delimiter",
+        ";",
+        "-",
+    }, &diag);
+    try std.testing.expectEqual(@as(u8, ';'), out.config.delimiter);
+}
+
+test "parse parses short delimiter option" {
+    var diag: clap.Diagnostic = .{};
+    const out = try Args.parse(std.testing.allocator, &.{
+        "-d",
+        ";",
+        "-",
+    }, &diag);
+    try std.testing.expectEqual(@as(u8, ';'), out.config.delimiter);
+}
+
+test "parse parses tab delimiter name" {
+    var diag: clap.Diagnostic = .{};
+    const out = try Args.parse(std.testing.allocator, &.{
+        "--delimiter",
+        "tab",
+        "-",
+    }, &diag);
+    try std.testing.expectEqual(@as(u8, '\t'), out.config.delimiter);
+}
+
+test "parse rejects multi-char delimiter" {
+    var diag: clap.Diagnostic = .{};
+    try std.testing.expectError(error.InvalidArgument, Args.parse(std.testing.allocator, &.{
+        "--delimiter",
+        ";;",
+    }, &diag));
 }
 
 test "parse rejects too many file arguments" {

--- a/src/csv.zig
+++ b/src/csv.zig
@@ -7,7 +7,7 @@ pub const Csv = struct {
     bufs: [][]u8,
 
     // Read a csv into memory with one owned buffer per row.
-    pub fn init(alloc: std.mem.Allocator, reader: anytype) !Csv {
+    pub fn init(alloc: std.mem.Allocator, reader: anytype, opts: struct { delimiter: u8 = ',' }) !Csv {
         var rows = std.ArrayList(Row).empty;
         var bufs = std.ArrayList([]u8).empty;
         errdefer {
@@ -17,7 +17,7 @@ pub const Csv = struct {
             bufs.deinit(alloc);
         }
 
-        var parser = zcsv.allocs.column.init(alloc, reader, .{});
+        var parser = zcsv.allocs.column.init(alloc, reader, .{ .column_delim = opts.delimiter });
         var width: ?usize = null;
         var next_ns: u64 = 0;
         var fields_ns: u64 = 0;
@@ -116,7 +116,7 @@ test "readCsv handles quoted comma and escaped quote" {
     const alloc = arena.allocator();
 
     var in = std.io.fixedBufferStream("a,b\n\"x,y\",\"say \"\"hi\"\"\"\n");
-    const csv = try Csv.init(alloc, in.reader());
+    const csv = try Csv.init(alloc, in.reader(), .{});
     try std.testing.expectEqual(2, csv.rows.len);
     try std.testing.expectEqualStrings("a", csv.rows[0][0]);
     try std.testing.expectEqualStrings("b", csv.rows[0][1]);
@@ -130,7 +130,7 @@ test "readCsv rejects jagged rows" {
     const alloc = arena.allocator();
 
     var in = std.io.fixedBufferStream("a,b\nc\n");
-    try std.testing.expectError(error.JaggedCsv, Csv.init(alloc, in.reader()));
+    try std.testing.expectError(error.JaggedCsv, Csv.init(alloc, in.reader(), .{}));
 }
 
 test "readCsv rejects malformed csv" {
@@ -139,13 +139,13 @@ test "readCsv rejects malformed csv" {
     const alloc = arena.allocator();
 
     var in = std.io.fixedBufferStream("a,b\n\"oops\n");
-    try std.testing.expectError(error.UnexpectedEndOfFile, Csv.init(alloc, in.reader()));
+    try std.testing.expectError(error.UnexpectedEndOfFile, Csv.init(alloc, in.reader(), .{}));
 }
 
 test "readCsv trims whitespace" {
     const alloc = std.testing.allocator;
     var in = std.io.fixedBufferStream(" a , b \n c , d \n");
-    const csv = try Csv.init(alloc, in.reader());
+    const csv = try Csv.init(alloc, in.reader(), .{});
     defer csv.deinit(alloc);
 
     try std.testing.expectEqualStrings("a", csv.rows[0][0]);
@@ -157,12 +157,48 @@ test "readCsv trims whitespace" {
 test "readCsv empty input yields empty header cell" {
     const alloc = std.testing.allocator;
     var in = std.io.fixedBufferStream("");
-    const csv = try Csv.init(alloc, in.reader());
+    const csv = try Csv.init(alloc, in.reader(), .{});
     defer csv.deinit(alloc);
 
     try std.testing.expectEqual(1, csv.rows.len);
     try std.testing.expectEqual(1, csv.rows[0].len);
     try std.testing.expectEqual(0, csv.rows[0][0].len);
+}
+
+test "readCsv with semicolon delimiter" {
+    const alloc = std.testing.allocator;
+    var in = std.io.fixedBufferStream("a;b\nc;d\n");
+    const csv = try Csv.init(alloc, in.reader(), .{ .delimiter = ';' });
+    defer csv.deinit(alloc);
+
+    try std.testing.expectEqual(2, csv.rows.len);
+    try std.testing.expectEqualStrings("a", csv.rows[0][0]);
+    try std.testing.expectEqualStrings("b", csv.rows[0][1]);
+    try std.testing.expectEqualStrings("c", csv.rows[1][0]);
+    try std.testing.expectEqualStrings("d", csv.rows[1][1]);
+}
+
+test "readCsv with tab delimiter" {
+    const alloc = std.testing.allocator;
+    var in = std.io.fixedBufferStream("a\tb\nc\td\n");
+    const csv = try Csv.init(alloc, in.reader(), .{ .delimiter = '\t' });
+    defer csv.deinit(alloc);
+
+    try std.testing.expectEqual(2, csv.rows.len);
+    try std.testing.expectEqualStrings("a", csv.rows[0][0]);
+    try std.testing.expectEqualStrings("b", csv.rows[0][1]);
+    try std.testing.expectEqualStrings("c", csv.rows[1][0]);
+    try std.testing.expectEqualStrings("d", csv.rows[1][1]);
+}
+
+test "readCsv semicolon delimiter preserves commas in fields" {
+    const alloc = std.testing.allocator;
+    var in = std.io.fixedBufferStream("a;b\nc,1;d\n");
+    const csv = try Csv.init(alloc, in.reader(), .{ .delimiter = ';' });
+    defer csv.deinit(alloc);
+
+    try std.testing.expectEqualStrings("c,1", csv.rows[1][0]);
+    try std.testing.expectEqualStrings("d", csv.rows[1][1]);
 }
 
 test "deinit releases owned rows" {

--- a/src/table.zig
+++ b/src/table.zig
@@ -17,7 +17,7 @@ pub const Table = struct {
         const table = try alloc.create(Table);
         errdefer alloc.destroy(table);
 
-        const csv = try Csv.init(alloc, reader);
+        const csv = try Csv.init(alloc, reader, .{ .delimiter = config.delimiter });
         errdefer csv.deinit(alloc);
 
         // A csv with zero data rows is intentionally rendered as "empty"
@@ -151,6 +151,19 @@ test "header only input is empty" {
     try std.testing.expectEqual(@as(usize, 0), table.headers().len);
     try std.testing.expectEqual(@as(usize, 0), table.nrows());
     try std.testing.expectEqual(@as(usize, 0), table.columns.len);
+}
+
+test "table with semicolon delimiter" {
+    var in = std.io.fixedBufferStream("a;b\nc;d\n");
+    const table = try Table.init(std.testing.allocator, .{ .delimiter = ';' }, in.reader());
+    defer table.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), table.headers().len);
+    try std.testing.expectEqualStrings("a", table.headers()[0]);
+    try std.testing.expectEqualStrings("b", table.headers()[1]);
+    try std.testing.expectEqual(@as(usize, 1), table.nrows());
+    try std.testing.expectEqualStrings("c", table.rows()[0][0]);
+    try std.testing.expectEqualStrings("d", table.rows()[0][1]);
 }
 
 test "rows returns data rows only" {

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,6 +1,7 @@
 // table config, from cli args
 pub const Config = struct {
     color: Color = .on,
+    delimiter: u8 = ',',
     row_numbers: bool = false,
     theme: Theme = .auto,
     title: []const u8 = "",


### PR DESCRIPTION
## Summary
- Adds `-d` / `--delimiter` CLI option to specify a custom field delimiter (default `,`)
- Supports any single ASCII character, plus the named value `tab` for tab-delimited files
- Closes #2

## Examples
```
tennis -d ";" data.csv
tennis --delimiter tab data.tsv
```

## Test plan
- [x] CSV parser tests with semicolon and tab delimiters
- [x] Semicolon delimiter preserves commas within fields
- [x] Args parsing: long option, short option, named `tab` value
- [x] Args parsing: rejects multi-character delimiters
- [x] End-to-end table test with semicolon delimiter
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)