### PR TITLE
Add first-pass Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test:
     strategy:
-      matrix: { platform: [ubuntu-latest, macos-latest, windows-latest] }
+      matrix: { platform: [ubuntu-latest, macos-15, macos-latest, windows-latest] }
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: jdx/mise-action@v3
-      - run: just check
+      - run: just ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,8 @@ name: ci
 
 on:
   pull_request:
-    paths-ignore: [README.md, justfile]
   push:
     branches: [main]
-    paths-ignore: [README.md, justfile]
   workflow_dispatch:
 
 concurrency:
@@ -15,12 +13,9 @@ concurrency:
 jobs:
   test:
     strategy:
-      matrix: { platform: [ubuntu-latest, macos-latest] }
+      matrix: { platform: [ubuntu-latest, macos-latest, windows-latest] }
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v5
-      - uses: mlugg/setup-zig@v2
-      - uses: taiki-e/install-action@just
-      - uses: bats-core/bats-action@4.0.0
-        with: { bats-version: "v1.13.0" } # seems to be required
-      - run: just ci
+      - uses: jdx/mise-action@v3
+      - run: just check

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,15 +6,18 @@ dist: tmp/dist
 builds:
   - builder: zig
     flags: ["-Doptimize=ReleaseSmall"]
-    targets: ["aarch64-linux", "aarch64-macos", "x86_64-linux"]
+    targets: ["aarch64-linux", "aarch64-macos", "x86_64-linux", "x86_64-macos", "x86_64-windows"]
 
 # what to put in the tgz files
 archives:
   - files:
       - extra/*
-      - LICENSE
+      - LICENSE-
       - README.md
     wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
 
 # turn stuff off
 announce: { skip: true }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
 archives:
   - files:
       - extra/*
-      - LICENSE-
+      - LICENSE
       - README.md
     wrap_in_directory: true
     format_overrides:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "printWidth": 120 }

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ We love CSV tools and use them all the time! Here are a few that we rely on:
 - style numeric columns. #35 (@jakob1379)
 - `--width min` to layout based on header width, or `--width max` to disable truncation
 - percent columns are justified (thanks @nkriege)
+- experimental windows binaries #38 (@S-U-V-E-N-D-U-P-A-N-D-A)
+- experimental macos-intel binaries #40 (@nafarinha)
 
 #### 0.4.0 (Apr '26)
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "clap-0.11.0-oBajB-HnAQDPCKYzwF7rO3qDFwRcD39Q0DALlTSz5H7e",
         },
         .mibu = .{
-            .url = "git+https://github.com/xyaman/mibu#b1644432384ac31ffeb45e83d3d3501a911e8865",
-            .hash = "mibu-0.0.1-dev-Ddr1rojEAABcqJWjDNhdeK_CWYjQUZlaGIvJwZOHJWf_",
+            .url = "git+https://github.com/xyaman/mibu#fa883b8d903573ca6ac44279f31d1317f0bcb595",
+            .hash = "mibu-0.0.1-dev-Ddr1rrDIAACi6HKDko6IdyxEpm_XaGYrPpAxyGnH2B3I",
         },
     },
     .fingerprint = 0x9420803bbcaa5265,

--- a/justfile
+++ b/justfile
@@ -1,6 +1,3 @@
-# Required for codex shell sessions where mise PATH hooks may not be active.
-export PATH := env("HOME") + "/.local/share/mise/installs/zig/0.15.2/bin:" + env("PATH")
-
 default:
   just --list
 

--- a/justfile
+++ b/justfile
@@ -10,6 +10,9 @@ build:
 build-release:
   zig build -Doptimize=ReleaseSmall
 
+build-windows:
+  zig build -Dtarget=x86_64-windows-gnu
+
 clean:
   rm -rf tmp zig-out
   mkdir tmp
@@ -27,8 +30,10 @@ run *ARGS:
 check: clean-weekly build lint test test-bats
   just banner "✓ check ✓"
 
+[unix]
 ci: check
-  just banner "✓ ci ✓"
+[windows]
+ci: build-windows
 
 clean-weekly:
   if [ -d tmp ] && [ "$(find tmp -type d -prune -mtime +7 | wc -l)" -gt 0 ]; then \

--- a/src/args.zig
+++ b/src/args.zig
@@ -178,7 +178,7 @@ pub const Args = struct {
         // now handle filename
         //
 
-        return try resolveInput(config, argv.len, res.positionals[0], util.isTty(std.fs.File.stdin()));
+        return try resolveInput(config, argv.len, res.positionals[0], std.fs.File.stdin().isTty());
     }
 
     // Resolve positional input into stdin, file, or banner behavior.

--- a/src/args.zig
+++ b/src/args.zig
@@ -122,8 +122,6 @@ pub const Args = struct {
 
     // Parse argv and map supported flags into config.
     fn parse(alloc: std.mem.Allocator, argv: []const []const u8, diag: *clap.Diagnostic) !MainEvent {
-        if (builtin.os.tag == .windows) return error.Windows;
-
         var iter = clap.args.SliceIterator{ .args = argv };
         var res = try clap.parseEx(clap.Help, &params, parsers, &iter, .{
             .allocator = alloc,
@@ -180,7 +178,7 @@ pub const Args = struct {
         // now handle filename
         //
 
-        return try resolveInput(config, argv.len, res.positionals[0], std.posix.isatty(std.fs.File.stdin().handle));
+        return try resolveInput(config, argv.len, res.positionals[0], util.isTty(std.fs.File.stdin()));
     }
 
     // Resolve positional input into stdin, file, or banner behavior.

--- a/src/detect.zig
+++ b/src/detect.zig
@@ -51,6 +51,7 @@ pub fn isSqliteFile(alloc: std.mem.Allocator, filename: ?[]const u8, input: std.
     // do we have an actual file?
     const path = filename orelse return false;
     if (std.mem.eql(u8, path, "-")) return false;
+    if (!util.isSeekable(input)) return false;
 
     // sample the first few bytes to look for sqlite3 magic
     var buf: [32]u8 = undefined;

--- a/src/failure.zig
+++ b/src/failure.zig
@@ -69,7 +69,7 @@ pub const Failure = struct {
 
     // Render one failure with the standard banner/footer behavior.
     pub fn print(self: Failure) !void {
-        try printBanner(util.stderr, self);
+        try printBanner(util.stderr(), self);
     }
 
     // Write one failure to the provided writer.

--- a/src/failure.zig
+++ b/src/failure.zig
@@ -69,7 +69,7 @@ pub const Failure = struct {
 
     // Render one failure with the standard banner/footer behavior.
     pub fn print(self: Failure) !void {
-        try printBanner(util.stderr(), self);
+        try printBanner(util.stderr, self);
     }
 
     // Write one failure to the provided writer.

--- a/src/main.zig
+++ b/src/main.zig
@@ -193,8 +193,7 @@ fn loadBytes(alloc: std.mem.Allocator, config: types.Config, bytes_in: []const u
 //
 
 fn renderToPager(alloc: std.mem.Allocator, config: types.Config, table: *Table) !void {
-    const cmd = (try util.getenv(alloc, "PAGER")) orelse try alloc.dupe(u8, "less");
-    defer alloc.free(cmd);
+    const cmd = util.getenv("PAGER") orelse "less";
     if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(alloc, config, table, util.stdout);
 
     var env = try std.process.getEnvMap(alloc);

--- a/src/main.zig
+++ b/src/main.zig
@@ -136,7 +136,7 @@ fn main0(alloc: std.mem.Allocator) !?failure.Failure {
     //
 
     timer = try std.time.Timer.start();
-    if (config.pager and builtin.os.tag != .windows and util.isTty(std.fs.File.stdout())) {
+    if (config.pager and builtin.os.tag != .windows and std.fs.File.stdout().isTty()) {
         try renderToPager(alloc, config, table);
     } else {
         try renderToWriter(alloc, config, table, util.stdout);

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,6 +4,8 @@
 //
 
 pub fn main() !void {
+    util.init();
+
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer {
         const check = gpa.deinit();
@@ -22,8 +24,8 @@ pub fn main() !void {
         exit = 1;
     }
 
-    util.stdout().flush() catch {};
-    util.stderr().flush() catch {};
+    util.stdout.flush() catch {};
+    util.stderr.flush() catch {};
     std.process.exit(exit);
 }
 
@@ -59,7 +61,7 @@ fn main0(alloc: std.mem.Allocator) !?failure.Failure {
     var config = switch (event) {
         .banner => {
             // plain `tennis` with no file/stdin prints the banner
-            try failure.printBanner(util.stdout(), null);
+            try failure.printBanner(util.stdout, null);
             return null;
         },
         .completion => |shell| {
@@ -71,12 +73,12 @@ fn main0(alloc: std.mem.Allocator) !?failure.Failure {
         .fatal => return event.takeFailure(),
         .help => {
             // help text bypasses the rest of the CLI
-            try util.stdout().writeAll(Args.help);
+            try util.stdout.writeAll(Args.help);
             return null;
         },
         .version => {
             // version is another direct early exit
-            try util.stdout().print("tennis: {s}\n", .{version});
+            try util.stdout.print("tennis: {s}\n", .{version});
             return null;
         },
         // otherwise keep the parsed config and continue
@@ -137,7 +139,7 @@ fn main0(alloc: std.mem.Allocator) !?failure.Failure {
     if (config.pager and builtin.os.tag != .windows and util.isTty(std.fs.File.stdout())) {
         try renderToPager(alloc, config, table);
     } else {
-        try renderToWriter(alloc, config, table, util.stdout());
+        try renderToWriter(alloc, config, table, util.stdout);
     }
 
     util.benchmark("table.render", timer.read());
@@ -192,7 +194,7 @@ fn loadBytes(alloc: std.mem.Allocator, config: types.Config, bytes_in: []const u
 fn renderToPager(alloc: std.mem.Allocator, config: types.Config, table: *Table) !void {
     const cmd = (try util.getenvOwned(alloc, "PAGER")) orelse try alloc.dupe(u8, "less");
     defer alloc.free(cmd);
-    if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(alloc, config, table, util.stdout());
+    if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(alloc, config, table, util.stdout);
 
     var env = try std.process.getEnvMap(alloc);
     defer env.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,7 @@
 
 pub fn main() !void {
     util.init();
+    defer util.deinit();
 
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer {
@@ -192,7 +193,7 @@ fn loadBytes(alloc: std.mem.Allocator, config: types.Config, bytes_in: []const u
 //
 
 fn renderToPager(alloc: std.mem.Allocator, config: types.Config, table: *Table) !void {
-    const cmd = (try util.getenvOwned(alloc, "PAGER")) orelse try alloc.dupe(u8, "less");
+    const cmd = (try util.getenv(alloc, "PAGER")) orelse try alloc.dupe(u8, "less");
     defer alloc.free(cmd);
     if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(alloc, config, table, util.stdout);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,8 +22,8 @@ pub fn main() !void {
         exit = 1;
     }
 
-    util.stdout.flush() catch {};
-    util.stderr.flush() catch {};
+    util.stdout().flush() catch {};
+    util.stderr().flush() catch {};
     std.process.exit(exit);
 }
 
@@ -59,7 +59,7 @@ fn main0(alloc: std.mem.Allocator) !?failure.Failure {
     var config = switch (event) {
         .banner => {
             // plain `tennis` with no file/stdin prints the banner
-            try failure.printBanner(util.stdout, null);
+            try failure.printBanner(util.stdout(), null);
             return null;
         },
         .completion => |shell| {
@@ -71,12 +71,12 @@ fn main0(alloc: std.mem.Allocator) !?failure.Failure {
         .fatal => return event.takeFailure(),
         .help => {
             // help text bypasses the rest of the CLI
-            try util.stdout.writeAll(Args.help);
+            try util.stdout().writeAll(Args.help);
             return null;
         },
         .version => {
             // version is another direct early exit
-            try util.stdout.print("tennis: {s}\n", .{version});
+            try util.stdout().print("tennis: {s}\n", .{version});
             return null;
         },
         // otherwise keep the parsed config and continue
@@ -134,10 +134,10 @@ fn main0(alloc: std.mem.Allocator) !?failure.Failure {
     //
 
     timer = try std.time.Timer.start();
-    if (config.pager and std.posix.isatty(std.fs.File.stdout().handle)) {
+    if (config.pager and builtin.os.tag != .windows and util.isTty(std.fs.File.stdout())) {
         try renderToPager(alloc, config, table);
     } else {
-        try renderToWriter(alloc, config, table, util.stdout);
+        try renderToWriter(alloc, config, table, util.stdout());
     }
 
     util.benchmark("table.render", timer.read());
@@ -190,8 +190,9 @@ fn loadBytes(alloc: std.mem.Allocator, config: types.Config, bytes_in: []const u
 //
 
 fn renderToPager(alloc: std.mem.Allocator, config: types.Config, table: *Table) !void {
-    const cmd = std.posix.getenv("PAGER") orelse "less";
-    if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(alloc, config, table, util.stdout);
+    const cmd = (try util.getenvOwned(alloc, "PAGER")) orelse try alloc.dupe(u8, "less");
+    defer alloc.free(cmd);
+    if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(alloc, config, table, util.stdout());
 
     var env = try std.process.getEnvMap(alloc);
     defer env.deinit();

--- a/src/style.zig
+++ b/src/style.zig
@@ -16,7 +16,7 @@ pub const Style = struct {
         return switch (theme) {
             .dark => dark,
             .light => light,
-            .auto => if (builtin.os.tag == .windows) dark else if (termbg.isDark(alloc) catch true) dark else light,
+            .auto => if (termbg.isDark(alloc) catch true) dark else light,
         };
     }
 

--- a/src/style.zig
+++ b/src/style.zig
@@ -93,7 +93,7 @@ fn colorEnabled(color: types.Color) bool {
         .auto => blk: {
             if (util.hasenv("NO_COLOR")) break :blk false;
             if (util.hasenv("FORCE_COLOR")) break :blk true;
-            if (!util.isTty(std.fs.File.stdout())) break :blk false;
+            if (!std.fs.File.stdout().isTty()) break :blk false;
             break :blk true;
         },
     };

--- a/src/style.zig
+++ b/src/style.zig
@@ -16,7 +16,7 @@ pub const Style = struct {
         return switch (theme) {
             .dark => dark,
             .light => light,
-            .auto => if (termbg.isDark(alloc) catch true) dark else light,
+            .auto => if (builtin.os.tag == .windows) dark else if (termbg.isDark(alloc) catch true) dark else light,
         };
     }
 
@@ -93,7 +93,7 @@ fn colorEnabled(color: types.Color) bool {
         .auto => blk: {
             if (util.hasenv("NO_COLOR")) break :blk false;
             if (util.hasenv("FORCE_COLOR")) break :blk true;
-            if (!std.posix.isatty(std.fs.File.stdout().handle)) break :blk false;
+            if (!util.isTty(std.fs.File.stdout())) break :blk false;
             break :blk true;
         },
     };
@@ -129,6 +129,7 @@ test "colorEnabled auto returns a boolean" {
     try testing.expect(colorEnabled(.auto) == true or colorEnabled(.auto) == false);
 }
 
+const builtin = @import("builtin");
 const Color = @import("color.zig").Color;
 const mibu = @import("mibu");
 const std = @import("std");

--- a/src/termbg.zig
+++ b/src/termbg.zig
@@ -7,17 +7,17 @@
 
 // Probe the terminal and report whether its background is dark.
 pub fn isDark(alloc: std.mem.Allocator) !bool {
-    if (builtin.os.tag == .windows) return error.NotSupported;
-
-    const term = util.getenv("TERM");
-
-    // open dev/tty
-    var devtty = std.fs.openFileAbsolute("/dev/tty", .{ .mode = .read_write }) catch |err| {
-        util.tdebug("could not open /dev/tty: {s}", .{@errorName(err)});
+    if (builtin.os.tag == .windows) {
         return error.NotSupported;
-    };
-    defer devtty.close();
-    return try isDarkWith(alloc, term, builtin.os.tag, RealTty{ .file = &devtty });
+    } else {
+        // open dev/tty. note - also fails on windows, which is totally fine
+        var devtty = std.fs.openFileAbsolute("/dev/tty", .{ .mode = .read_write }) catch |err| {
+            util.tdebug("could not open /dev/tty: {s}", .{@errorName(err)});
+            return error.NotSupported;
+        };
+        defer devtty.close();
+        return try isDarkWith(alloc, util.getenv("TERM"), builtin.os.tag, RealTty{ .file = &devtty });
+    }
 }
 
 // Probe terminal background color through an abstract tty interface.
@@ -98,9 +98,7 @@ fn isOsc11Response(response: []const u8) bool {
     return response.len >= 2 and response[1] == ']';
 }
 
-const RealTty = if (builtin.os.tag == .windows) struct {
-    file: *std.fs.File,
-} else struct {
+const RealTty = if (builtin.os.tag != .windows) struct {
     file: *std.fs.File,
 
     // Fetch the current terminal attributes.
@@ -122,6 +120,8 @@ const RealTty = if (builtin.os.tag == .windows) struct {
     fn readResponse(self: @This(), alloc: std.mem.Allocator) ![]u8 {
         return try termReadResponse(alloc, self.file.handle);
     }
+} else struct {
+    file: *std.fs.File,
 };
 
 //

--- a/src/termbg.zig
+++ b/src/termbg.zig
@@ -9,8 +9,7 @@
 pub fn isDark(alloc: std.mem.Allocator) !bool {
     if (builtin.os.tag == .windows) return error.NotSupported;
 
-    const term = try util.getenv(alloc, "TERM");
-    defer if (term) |value| alloc.free(value);
+    const term = util.getenv("TERM");
 
     // open dev/tty
     var devtty = std.fs.openFileAbsolute("/dev/tty", .{ .mode = .read_write }) catch |err| {

--- a/src/termbg.zig
+++ b/src/termbg.zig
@@ -9,7 +9,7 @@
 pub fn isDark(alloc: std.mem.Allocator) !bool {
     if (builtin.os.tag == .windows) return error.NotSupported;
 
-    const term = try util.getenvOwned(alloc, "TERM");
+    const term = try util.getenv(alloc, "TERM");
     defer if (term) |value| alloc.free(value);
 
     // open dev/tty

--- a/src/termbg.zig
+++ b/src/termbg.zig
@@ -7,13 +7,18 @@
 
 // Probe the terminal and report whether its background is dark.
 pub fn isDark(alloc: std.mem.Allocator) !bool {
+    if (builtin.os.tag == .windows) return error.NotSupported;
+
+    const term = try util.getenvOwned(alloc, "TERM");
+    defer if (term) |value| alloc.free(value);
+
     // open dev/tty
     var devtty = std.fs.openFileAbsolute("/dev/tty", .{ .mode = .read_write }) catch |err| {
         util.tdebug("could not open /dev/tty: {s}", .{@errorName(err)});
         return error.NotSupported;
     };
     defer devtty.close();
-    return try isDarkWith(alloc, std.posix.getenv("TERM"), builtin.os.tag, RealTty{ .file = &devtty });
+    return try isDarkWith(alloc, term, builtin.os.tag, RealTty{ .file = &devtty });
 }
 
 // Probe terminal background color through an abstract tty interface.
@@ -94,7 +99,9 @@ fn isOsc11Response(response: []const u8) bool {
     return response.len >= 2 and response[1] == ']';
 }
 
-const RealTty = struct {
+const RealTty = if (builtin.os.tag == .windows) struct {
+    file: *std.fs.File,
+} else struct {
     file: *std.fs.File,
 
     // Fetch the current terminal attributes.

--- a/src/termbg.zig
+++ b/src/termbg.zig
@@ -7,17 +7,15 @@
 
 // Probe the terminal and report whether its background is dark.
 pub fn isDark(alloc: std.mem.Allocator) !bool {
-    if (builtin.os.tag == .windows) {
+    if (builtin.os.tag == .windows) return error.NotSupported; // not yet
+
+    // open dev/tty. note - also fails on windows, which is totally fine
+    var devtty = std.fs.openFileAbsolute("/dev/tty", .{ .mode = .read_write }) catch |err| {
+        util.tdebug("could not open /dev/tty: {s}", .{@errorName(err)});
         return error.NotSupported;
-    } else {
-        // open dev/tty. note - also fails on windows, which is totally fine
-        var devtty = std.fs.openFileAbsolute("/dev/tty", .{ .mode = .read_write }) catch |err| {
-            util.tdebug("could not open /dev/tty: {s}", .{@errorName(err)});
-            return error.NotSupported;
-        };
-        defer devtty.close();
-        return try isDarkWith(alloc, util.getenv("TERM"), builtin.os.tag, RealTty{ .file = &devtty });
-    }
+    };
+    defer devtty.close();
+    return try isDarkWith(alloc, util.getenv("TERM"), builtin.os.tag, RealTty{ .file = &devtty });
 }
 
 // Probe terminal background color through an abstract tty interface.

--- a/src/util.zig
+++ b/src/util.zig
@@ -8,16 +8,15 @@ var stderr_buf: [4096]u8 = undefined;
 var stdout0: ?std.fs.File.Writer = null;
 var stderr0: ?std.fs.File.Writer = null;
 
-// Return the shared buffered stdout writer, initializing it on first use.
-pub fn stdout() *std.Io.Writer {
-    if (stdout0 == null) stdout0 = .init(std.fs.File.stdout(), &stdout_buf);
-    return &stdout0.?.interface;
-}
+pub var stdout: *std.Io.Writer = undefined;
+pub var stderr: *std.Io.Writer = undefined;
 
-// Return the shared buffered stderr writer, initializing it on first use.
-pub fn stderr() *std.Io.Writer {
-    if (stderr0 == null) stderr0 = .init(std.fs.File.stderr(), &stderr_buf);
-    return &stderr0.?.interface;
+// Initialize the shared buffered stdout/stderr writers.
+pub fn init() void {
+    stdout0 = .init(std.fs.File.stdout(), &stdout_buf);
+    stderr0 = .init(std.fs.File.stderr(), &stderr_buf);
+    stdout = &stdout0.?.interface;
+    stderr = &stderr0.?.interface;
 }
 
 //
@@ -227,8 +226,8 @@ pub fn benchmark(label: []const u8, elapsed_ns: u64) void {
     if (!hasenv("BENCHMARK")) return;
     const ms = elapsed_ns / std.time.ns_per_ms;
     const frac = (elapsed_ns % std.time.ns_per_ms) / std.time.ns_per_us;
-    stderr().print("{s:<17} {d:>8}.{d:0>3} ms\n", .{ label, ms, frac }) catch {};
-    stderr().flush() catch {};
+    stderr.print("{s:<17} {d:>8}.{d:0>3} ms\n", .{ label, ms, frac }) catch {};
+    stderr.flush() catch {};
 }
 
 // does this env var exist?
@@ -249,8 +248,8 @@ pub fn getenvOwned(alloc: std.mem.Allocator, name: []const u8) !?[]u8 {
 // debug logging to stderr, enabled only with TENNIS_DEBUG=1 (or any value)
 pub fn tdebug(comptime fmt: []const u8, args: anytype) void {
     if (!hasenv("TENNIS_DEBUG")) return;
-    stderr().print("tennis: " ++ fmt ++ "\n", args) catch {};
-    stderr().flush() catch {};
+    stderr.print("tennis: " ++ fmt ++ "\n", args) catch {};
+    stderr.flush() catch {};
 }
 
 // how wide is the terminal? thanks mubi

--- a/src/util.zig
+++ b/src/util.zig
@@ -263,15 +263,17 @@ pub fn tdebug(comptime fmt: []const u8, args: anytype) void {
 
 // how wide is the terminal? thanks mubi
 pub fn termWidth() usize {
-    if (mibu.term.getSize(std.fs.File.stdout().handle)) |size| {
-        if (size.width > 0) return @intCast(size.width);
-    } else |_| {}
+    const handle = switch (builtin.os.tag) {
+        .linux, .macos => blk: {
+            var tty = std.fs.openFileAbsolute("/dev/tty", .{}) catch return 80;
+            defer tty.close();
+            break :blk tty.handle;
+        },
+        .windows => std.fs.File.stdout().handle,
+        else => unreachable,
+    };
 
-    if (builtin.os.tag == .windows) return 80;
-    var tty = std.fs.openFileAbsolute("/dev/tty", .{}) catch return 80;
-    defer tty.close();
-
-    if (mibu.term.getSize(tty.handle)) |size| {
+    if (mibu.term.getSize(handle)) |size| {
         if (size.width > 0) return @intCast(size.width);
     } else |_| {}
     return 80;

--- a/src/util.zig
+++ b/src/util.zig
@@ -5,11 +5,20 @@
 var stdout_buf: [4096]u8 = undefined;
 var stderr_buf: [4096]u8 = undefined;
 
-var stdout0: std.fs.File.Writer = .init(std.fs.File.stdout(), &stdout_buf);
-var stderr0: std.fs.File.Writer = .init(std.fs.File.stderr(), &stderr_buf);
+var stdout0: ?std.fs.File.Writer = null;
+var stderr0: ?std.fs.File.Writer = null;
 
-pub const stdout = &stdout0.interface;
-pub const stderr = &stderr0.interface;
+// Return the shared buffered stdout writer, initializing it on first use.
+pub fn stdout() *std.Io.Writer {
+    if (stdout0 == null) stdout0 = .init(std.fs.File.stdout(), &stdout_buf);
+    return &stdout0.?.interface;
+}
+
+// Return the shared buffered stderr writer, initializing it on first use.
+pub fn stderr() *std.Io.Writer {
+    if (stderr0 == null) stderr0 = .init(std.fs.File.stderr(), &stderr_buf);
+    return &stderr0.?.interface;
+}
 
 //
 // files
@@ -27,6 +36,11 @@ pub fn isSeekable(file: std.fs.File) bool {
     const pos = file.getPos() catch return false;
     file.seekTo(pos) catch return false;
     return true;
+}
+
+// Report whether one file handle refers to a TTY.
+pub fn isTty(file: std.fs.File) bool {
+    return file.isTty();
 }
 
 // read a single byte from an fd
@@ -213,24 +227,35 @@ pub fn benchmark(label: []const u8, elapsed_ns: u64) void {
     if (!hasenv("BENCHMARK")) return;
     const ms = elapsed_ns / std.time.ns_per_ms;
     const frac = (elapsed_ns % std.time.ns_per_ms) / std.time.ns_per_us;
-    stderr.print("{s:<17} {d:>8}.{d:0>3} ms\n", .{ label, ms, frac }) catch {};
-    stderr.flush() catch {};
+    stderr().print("{s:<17} {d:>8}.{d:0>3} ms\n", .{ label, ms, frac }) catch {};
+    stderr().flush() catch {};
 }
 
 // does this env var exist?
 pub fn hasenv(name: []const u8) bool {
-    return std.posix.getenv(name) != null;
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, name) catch return false;
+    defer std.heap.page_allocator.free(value);
+    return true;
+}
+
+// Return one owned env var value when present.
+pub fn getenvOwned(alloc: std.mem.Allocator, name: []const u8) !?[]u8 {
+    return std.process.getEnvVarOwned(alloc, name) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
 }
 
 // debug logging to stderr, enabled only with TENNIS_DEBUG=1 (or any value)
 pub fn tdebug(comptime fmt: []const u8, args: anytype) void {
     if (!hasenv("TENNIS_DEBUG")) return;
-    stderr.print("tennis: " ++ fmt ++ "\n", args) catch {};
-    stderr.flush() catch {};
+    stderr().print("tennis: " ++ fmt ++ "\n", args) catch {};
+    stderr().flush() catch {};
 }
 
 // how wide is the terminal? thanks mubi
 pub fn termWidth() usize {
+    if (builtin.os.tag == .windows) return 80;
     var tty = std.fs.openFileAbsolute("/dev/tty", .{}) catch return 80;
     defer tty.close();
 
@@ -417,6 +442,7 @@ test "termWidth returns a positive width" {
     try testing.expect(termWidth() > 0);
 }
 
+const builtin = @import("builtin");
 const int = @import("int.zig");
 const mibu = @import("mibu");
 const std = @import("std");

--- a/src/util.zig
+++ b/src/util.zig
@@ -263,6 +263,10 @@ pub fn tdebug(comptime fmt: []const u8, args: anytype) void {
 
 // how wide is the terminal? thanks mubi
 pub fn termWidth() usize {
+    if (mibu.term.getSize(std.fs.File.stdout().handle)) |size| {
+        if (size.width > 0) return @intCast(size.width);
+    } else |_| {}
+
     if (builtin.os.tag == .windows) return 80;
     var tty = std.fs.openFileAbsolute("/dev/tty", .{}) catch return 80;
     defer tty.close();
@@ -336,8 +340,6 @@ test "fileExists" {
 }
 
 test "hasenv" {
-    init();
-    defer deinit();
     try testing.expect(hasenv("PATH"));
     try testing.expect(!hasenv("TENNIS_TEST_ENV_DOES_NOT_EXIST"));
 }
@@ -441,13 +443,6 @@ test "lowerAscii" {
 
 test "sum" {
     try testing.expectEqual(@as(usize, 10), sum(usize, &.{ 1, 2, 3, 4 }));
-}
-
-test "tdebug" {
-    init();
-    defer deinit();
-    tdebug("off {d}", .{1});
-    tdebug("on {d}", .{2});
 }
 
 test "termWidth returns a positive width" {

--- a/src/util.zig
+++ b/src/util.zig
@@ -37,11 +37,6 @@ pub fn isSeekable(file: std.fs.File) bool {
     return true;
 }
 
-// Report whether one file handle refers to a TTY.
-pub fn isTty(file: std.fs.File) bool {
-    return file.isTty();
-}
-
 // read a single byte from an fd
 pub fn readByte(fd: std.posix.fd_t) !u8 {
     var buf: [1]u8 = undefined;

--- a/src/util.zig
+++ b/src/util.zig
@@ -2,14 +2,15 @@
 // convenient stdout/stderr buffered writers
 //
 
+pub var stdout: *std.Io.Writer = undefined;
+pub var stderr: *std.Io.Writer = undefined;
+
 var stdout_buf: [4096]u8 = undefined;
 var stderr_buf: [4096]u8 = undefined;
 
 var stdout0: ?std.fs.File.Writer = null;
 var stderr0: ?std.fs.File.Writer = null;
-
-pub var stdout: *std.Io.Writer = undefined;
-pub var stderr: *std.Io.Writer = undefined;
+var env: ?std.process.EnvMap = null;
 
 // Initialize the shared buffered stdout/stderr writers.
 pub fn init() void {
@@ -17,6 +18,13 @@ pub fn init() void {
     stderr0 = .init(std.fs.File.stderr(), &stderr_buf);
     stdout = &stdout0.?.interface;
     stderr = &stderr0.?.interface;
+    ensureEnv();
+}
+
+// Release any shared runtime state initialized by init().
+pub fn deinit() void {
+    if (env) |*env0| env0.deinit();
+    env = null;
 }
 
 //
@@ -213,6 +221,29 @@ pub fn upperAscii(dest: []u8, src: []const u8) []const u8 {
 }
 
 //
+// env
+//
+
+// Initialize the cached environment map on first use.
+fn ensureEnv() void {
+    if (env != null) return;
+    env = std.process.getEnvMap(std.heap.page_allocator) catch @panic("could not load env");
+}
+
+// does this env var exist?
+pub fn hasenv(name: []const u8) bool {
+    ensureEnv();
+    return env.?.get(name) != null;
+}
+
+// Return one owned env var value when present.
+pub fn getenv(alloc: std.mem.Allocator, name: []const u8) !?[]u8 {
+    ensureEnv();
+    const value = env.?.get(name) orelse return null;
+    return try alloc.dupe(u8, value);
+}
+
+//
 // misc
 //
 
@@ -223,21 +254,6 @@ pub fn benchmark(label: []const u8, elapsed_ns: u64) void {
     const frac = (elapsed_ns % std.time.ns_per_ms) / std.time.ns_per_us;
     stderr.print("{s:<17} {d:>8}.{d:0>3} ms\n", .{ label, ms, frac }) catch {};
     stderr.flush() catch {};
-}
-
-// does this env var exist?
-pub fn hasenv(name: []const u8) bool {
-    const value = std.process.getEnvVarOwned(std.heap.page_allocator, name) catch return false;
-    defer std.heap.page_allocator.free(value);
-    return true;
-}
-
-// Return one owned env var value when present.
-pub fn getenvOwned(alloc: std.mem.Allocator, name: []const u8) !?[]u8 {
-    return std.process.getEnvVarOwned(alloc, name) catch |err| switch (err) {
-        error.EnvironmentVariableNotFound => null,
-        else => return err,
-    };
 }
 
 // debug logging to stderr, enabled only with TENNIS_DEBUG=1 (or any value)
@@ -322,6 +338,8 @@ test "fileExists" {
 }
 
 test "hasenv" {
+    init();
+    defer deinit();
     try testing.expect(hasenv("PATH"));
     try testing.expect(!hasenv("TENNIS_TEST_ENV_DOES_NOT_EXIST"));
 }
@@ -428,6 +446,8 @@ test "sum" {
 }
 
 test "tdebug" {
+    init();
+    defer deinit();
     tdebug("off {d}", .{1});
     tdebug("on {d}", .{2});
 }

--- a/src/util.zig
+++ b/src/util.zig
@@ -12,13 +12,17 @@ var stdout0: ?std.fs.File.Writer = null;
 var stderr0: ?std.fs.File.Writer = null;
 var env: ?std.process.EnvMap = null;
 
+//
+// init/deinit
+//
+
 // Initialize the shared buffered stdout/stderr writers.
 pub fn init() void {
     stdout0 = .init(std.fs.File.stdout(), &stdout_buf);
     stderr0 = .init(std.fs.File.stderr(), &stderr_buf);
     stdout = &stdout0.?.interface;
     stderr = &stderr0.?.interface;
-    ensureEnv();
+    env = std.process.getEnvMap(std.heap.page_allocator) catch @panic("could not load env");
 }
 
 // Release any shared runtime state initialized by init().
@@ -222,13 +226,8 @@ pub fn upperAscii(dest: []u8, src: []const u8) []const u8 {
 
 //
 // env
+// Note: to use these only work if you call util.init, otherwise they always return null
 //
-
-// Initialize the cached environment map on first use.
-fn ensureEnv() void {
-    if (env != null) return;
-    env = std.process.getEnvMap(std.heap.page_allocator) catch @panic("could not load env");
-}
 
 // does this env var exist?
 pub fn hasenv(name: []const u8) bool {
@@ -237,8 +236,7 @@ pub fn hasenv(name: []const u8) bool {
 
 // Return one borrowed env var value when present.
 pub fn getenv(name: []const u8) ?[]const u8 {
-    ensureEnv();
-    return env.?.get(name);
+    return if (env) |env0| env0.get(name) else null;
 }
 
 //
@@ -264,13 +262,12 @@ pub fn tdebug(comptime fmt: []const u8, args: anytype) void {
 // how wide is the terminal? thanks mubi
 pub fn termWidth() usize {
     const handle = switch (builtin.os.tag) {
-        .linux, .macos => blk: {
+        .windows => std.fs.File.stdout().handle,
+        else => blk: {
             var tty = std.fs.openFileAbsolute("/dev/tty", .{}) catch return 80;
             defer tty.close();
             break :blk tty.handle;
         },
-        .windows => std.fs.File.stdout().handle,
-        else => unreachable,
     };
 
     if (mibu.term.getSize(handle)) |size| {
@@ -342,6 +339,8 @@ test "fileExists" {
 }
 
 test "hasenv" {
+    init();
+    defer deinit();
     try testing.expect(hasenv("PATH"));
     try testing.expect(!hasenv("TENNIS_TEST_ENV_DOES_NOT_EXIST"));
 }

--- a/src/util.zig
+++ b/src/util.zig
@@ -232,15 +232,13 @@ fn ensureEnv() void {
 
 // does this env var exist?
 pub fn hasenv(name: []const u8) bool {
-    ensureEnv();
-    return env.?.get(name) != null;
+    return getenv(name) != null;
 }
 
-// Return one owned env var value when present.
-pub fn getenv(alloc: std.mem.Allocator, name: []const u8) !?[]u8 {
+// Return one borrowed env var value when present.
+pub fn getenv(name: []const u8) ?[]const u8 {
     ensureEnv();
-    const value = env.?.get(name) orelse return null;
-    return try alloc.dupe(u8, value);
+    return env.?.get(name);
 }
 
 //


### PR DESCRIPTION
- first-pass windows support: build cleanly, default auto theme to dark, and use platform-aware io/env/tty handling
- update mibu and wire ci/build helpers for windows; native tests and windows cross-build pass
