### PR TITLE
Centralize env handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .zig-cache
 std.md
 tmp/
-zig-pkg/
 zig-out/
+zig-pkg/

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ We love CSV tools and use them all the time! Here are a few that we rely on:
 
 #### 0.5.0 (unreleased)
 
+- zig 0.16 and centralize env handling. #45
 - style numeric columns. #35 (@jakob1379)
 - `--width min` to layout based on header width, or `--width max` to disable truncation
 - percent columns are justified (thanks @nkriege)

--- a/src/app.zig
+++ b/src/app.zig
@@ -108,7 +108,7 @@ test "testInit exposes env" {
     const app = try App.testInit(testing.allocator);
     defer app.destroy();
 
-    try testing.expect(app.env.get("PATH") != null);
+    try testing.expect(app.env.PATH != null);
     _ = std.Io.File.stdin().isTty(app.io) catch false;
     _ = std.Io.File.stdout().isTty(app.io) catch false;
 }

--- a/src/app.zig
+++ b/src/app.zig
@@ -4,8 +4,7 @@
 pub const App = struct {
     alloc: std.mem.Allocator,
     io: std.Io,
-    environ: std.process.Environ,
-    env: std.process.Environ.Map,
+    env: Env,
     stdout_buf: [4096]u8 = undefined,
     stderr_buf: [4096]u8 = undefined,
     stdout_writer: std.Io.File.Writer = undefined,
@@ -30,12 +29,7 @@ pub const App = struct {
     // Initialize one App from explicit runtime pieces.
     fn initFrom(alloc: std.mem.Allocator, io: std.Io, environ: std.process.Environ) !*Self {
         const app = try alloc.create(Self);
-        app.* = .{
-            .alloc = alloc,
-            .io = io,
-            .environ = environ,
-            .env = try std.process.Environ.createMap(environ, alloc),
-        };
+        app.* = .{ .alloc = alloc, .io = io, .env = try Env.init(alloc, environ) };
         app.stdout_writer = std.Io.File.stdout().writerStreaming(io, &app.stdout_buf);
         app.stderr_writer = std.Io.File.stderr().writerStreaming(io, &app.stderr_buf);
         return app;
@@ -63,19 +57,9 @@ pub const App = struct {
         self.stderr().flush() catch {};
     }
 
-    // Report whether one env var exists.
-    pub fn hasenv(self: *const Self, name: []const u8) bool {
-        return self.getenv(name) != null;
-    }
-
-    // Return one borrowed env var value when present.
-    pub fn getenv(self: *const Self, name: []const u8) ?[]const u8 {
-        return self.env.get(name);
-    }
-
     // Print one benchmark line when BENCHMARK is enabled.
     pub fn benchmark(self: *const Self, label: []const u8, elapsed_ns: u64) void {
-        if (!self.hasenv("BENCHMARK")) return;
+        if (!self.env.BENCHMARK) return;
         const ms = elapsed_ns / std.time.ns_per_ms;
         const frac = (elapsed_ns % std.time.ns_per_ms) / std.time.ns_per_us;
         var buf: [256]u8 = undefined;
@@ -86,7 +70,7 @@ pub const App = struct {
 
     // Print one debug line when TENNIS_DEBUG is enabled.
     pub fn tdebug(self: *const Self, comptime fmt: []const u8, args: anytype) void {
-        if (!self.hasenv("TENNIS_DEBUG")) return;
+        if (!self.env.TENNIS_DEBUG) return;
         var buf: [256]u8 = undefined;
         var writer = std.Io.File.stderr().writerStreaming(self.io, &buf);
         writer.interface.print("tennis: " ++ fmt ++ "\n", args) catch {};
@@ -124,7 +108,7 @@ test "testInit exposes env" {
     const app = try App.testInit(testing.allocator);
     defer app.destroy();
 
-    try testing.expect(app.hasenv("PATH"));
+    try testing.expect(app.env.get("PATH") != null);
     _ = std.Io.File.stdin().isTty(app.io) catch false;
     _ = std.Io.File.stdout().isTty(app.io) catch false;
 }
@@ -137,6 +121,7 @@ test "termWidth returns a positive width" {
 }
 
 const builtin = @import("builtin");
+const Env = @import("env.zig").Env;
 const mibu = @import("mibu");
 const std = @import("std");
 const testing = std.testing;

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,0 +1,51 @@
+// Typed runtime environment settings plus raw environment access.
+pub const Env = struct {
+    map: std.process.Environ.Map,
+
+    BENCHMARK: bool = undefined,
+    FORCE_COLOR: bool = undefined,
+    NO_COLOR: bool = undefined,
+    PAGER: ?[]const u8 = undefined,
+    TENNIS_DEBUG: bool = undefined,
+    TERM: ?[]const u8 = undefined,
+
+    const Self = @This();
+
+    // Build one typed environment view from the process environment.
+    pub fn init(alloc: std.mem.Allocator, environ: std.process.Environ) !Env {
+        var map = try std.process.Environ.createMap(environ, alloc);
+        errdefer map.deinit();
+
+        var env: Env = .{ .map = map };
+        env.BENCHMARK = env.has("BENCHMARK");
+        env.FORCE_COLOR = env.has("FORCE_COLOR");
+        env.NO_COLOR = env.has("NO_COLOR");
+        env.PAGER = env.get("PAGER");
+        env.TENNIS_DEBUG = env.has("TENNIS_DEBUG");
+        env.TERM = env.get("TERM");
+
+        return env;
+    }
+
+    // Release the owned raw environment map.
+    pub fn deinit(self: *Self) void {
+        self.map.deinit();
+    }
+
+    // Report whether one env var exists.
+    pub fn has(self: *const Self, name: []const u8) bool {
+        return self.get(name) != null;
+    }
+
+    // Return one borrowed env var value when present.
+    pub fn get(self: *const Self, name: []const u8) ?[]const u8 {
+        return self.map.get(name);
+    }
+
+    // Return one cloned environment map for child process spawning.
+    pub fn clone(self: *const Self, alloc: std.mem.Allocator) !std.process.Environ.Map {
+        return try std.process.Environ.Map.clone(&self.map, alloc);
+    }
+};
+
+const std = @import("std");

--- a/src/env.zig
+++ b/src/env.zig
@@ -4,8 +4,10 @@ pub const Env = struct {
 
     BENCHMARK: bool = undefined,
     FORCE_COLOR: bool = undefined,
+    LESS: ?[]const u8 = undefined,
     NO_COLOR: bool = undefined,
     PAGER: ?[]const u8 = undefined,
+    PATH: ?[]const u8 = undefined,
     TENNIS_DEBUG: bool = undefined,
     TERM: ?[]const u8 = undefined,
 
@@ -19,11 +21,12 @@ pub const Env = struct {
         var env: Env = .{ .map = map };
         env.BENCHMARK = env.has("BENCHMARK");
         env.FORCE_COLOR = env.has("FORCE_COLOR");
+        env.LESS = env.get("LESS");
         env.NO_COLOR = env.has("NO_COLOR");
         env.PAGER = env.get("PAGER");
+        env.PATH = env.get("PATH");
         env.TENNIS_DEBUG = env.has("TENNIS_DEBUG");
         env.TERM = env.get("TERM");
-
         return env;
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -190,7 +190,7 @@ fn renderToPager(app: *App, config: types.Config, table: *Table) !void {
 
     var env = try app.env.clone(app.alloc);
     defer env.deinit();
-    if (env.get("LESS") == null) try env.put("LESS", "FRX");
+    if (app.env.LESS == null) try env.put("LESS", "FRX");
 
     var child = try std.process.spawn(app.io, .{
         .argv = &.{ "/bin/sh", "-c", cmd },

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,7 +33,7 @@ fn main0(app: *App, process_args: std.process.Args) !?failure.Failure {
     defer app.benchmark("total", util.timerRead(app.io, total));
 
     // sanity checks
-    if (app.hasenv("BENCHMARK") and builtin.mode == .Debug) {
+    if (app.env.BENCHMARK and builtin.mode == .Debug) {
         return .{ .code = .benchmark_requires_release };
     }
 
@@ -185,10 +185,10 @@ fn loadBytes(app: *App, config: types.Config, bytes_in: []const u8) !Data {
 
 fn renderToPager(app: *App, config: types.Config, table: *Table) !void {
     if (builtin.os.tag == .windows) return renderToWriter(app, config, table, app.stdout());
-    const cmd = app.getenv("PAGER") orelse "less";
+    const cmd = app.env.PAGER orelse "less";
     if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(app, config, table, app.stdout());
 
-    var env = try std.process.Environ.createMap(app.environ, app.alloc);
+    var env = try app.env.clone(app.alloc);
     defer env.deinit();
     if (env.get("LESS") == null) try env.put("LESS", "FRX");
 

--- a/src/style.zig
+++ b/src/style.zig
@@ -91,8 +91,8 @@ fn colorEnabled(app: *const App, color: types.Color) bool {
         .on => true,
         .off => false,
         .auto => blk: {
-            if (app.hasenv("NO_COLOR")) break :blk false;
-            if (app.hasenv("FORCE_COLOR")) break :blk true;
+            if (app.env.NO_COLOR) break :blk false;
+            if (app.env.FORCE_COLOR) break :blk true;
             if (!(std.Io.File.stdout().isTty(app.io) catch false)) break :blk false;
             break :blk true;
         },

--- a/src/termbg.zig
+++ b/src/termbg.zig
@@ -15,7 +15,7 @@ pub fn isDark(app: *App) !bool {
         return error.NotSupported;
     };
     defer devtty.close(app.io);
-    return try isDarkWith(app, app.getenv("TERM"), builtin.os.tag, RealTty{ .app = app, .file = &devtty });
+    return try isDarkWith(app, app.env.TERM, builtin.os.tag, RealTty{ .app = app, .file = &devtty });
 }
 
 // Probe terminal background color through an abstract tty interface.


### PR DESCRIPTION
- centralize runtime environment handling in src/env.zig
- replace scattered env lookups with a typed Env on App
