### PR TITLE
Fix pager startup

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -188,15 +188,19 @@ fn loadBytes(app: *App, config: types.Config, bytes_in: []const u8) !Data {
 
 fn renderToPager(app: *App, table: *Table) !void {
     if (builtin.os.tag == .windows) return renderToWriter(app, table, app.stdout());
-    const cmd = app.env.PAGER orelse "less";
-    if (std.mem.eql(u8, cmd, "cat")) return renderToWriter(app, table, app.stdout());
+    const argv = try pagerArgv(app);
+    defer util.deepFree(u8, app.alloc, argv);
+    if (argv.len == 1 and std.mem.eql(u8, argv[0], "cat")) return renderToWriter(app, table, app.stdout());
 
     var env = try app.env.clone(app.alloc);
     defer env.deinit();
-    if (app.env.LESS == null) try env.put("LESS", "FRX");
+
+    // Init style early in this case, because termbg mucks with termios. Doing
+    // that AFTER pager startup breaks all pager key handling.
+    _ = table.style();
 
     var child = try std.process.spawn(app.io, .{
-        .argv = &.{ "/bin/sh", "-c", cmd },
+        .argv = argv,
         .environ_map = &env,
         .stdin = .pipe,
         .stdout = .inherit,
@@ -219,6 +223,16 @@ fn renderToPager(app: *App, table: *Table) !void {
 
     _ = try child.wait(app.io);
     waited = true;
+}
+
+// Return pager argv from $PAGER or the default ANSI-aware less command.
+fn pagerArgv(app: *App) ![]const []const u8 {
+    if (app.env.PAGER) |cmd| {
+        const argv = try util.shellsplit(app.alloc, cmd);
+        if (argv.len > 0) return argv;
+        util.deepFree(u8, app.alloc, argv);
+    }
+    return try util.deepDupe(u8, app.alloc, &.{ "less", "--RAW-CONTROL-CHARS" });
 }
 
 fn renderToWriter(app: *App, table: *Table, writer: *std.Io.Writer) !void {

--- a/src/util.zig
+++ b/src/util.zig
@@ -129,6 +129,53 @@ pub fn inspect(alloc: std.mem.Allocator, s: []const u8) ![]u8 {
     return out.toOwnedSlice(alloc);
 }
 
+// Split one shell-like command string into argv.
+pub fn shellsplit(alloc: std.mem.Allocator, cmd: []const u8) ![]const []const u8 {
+    var args = std.ArrayList([]const u8).empty;
+    errdefer {
+        for (args.items) |arg| alloc.free(arg);
+        args.deinit(alloc);
+    }
+
+    var token = std.ArrayList(u8).empty;
+    defer token.deinit(alloc);
+
+    var quote: ?u8 = null;
+    var escaped = false;
+    for (cmd) |ch| {
+        if (escaped) {
+            try token.append(alloc, ch);
+            escaped = false;
+            continue;
+        }
+        if (ch == '\\') {
+            escaped = true;
+            continue;
+        }
+        if (quote) |q| {
+            if (ch == q) {
+                quote = null;
+            } else {
+                try token.append(alloc, ch);
+            }
+            continue;
+        }
+        switch (ch) {
+            '\t', '\n', '\r', ' ' => if (token.items.len > 0) {
+                try args.append(alloc, try token.toOwnedSlice(alloc));
+                token.clearRetainingCapacity();
+            },
+            '\'', '"' => quote = ch,
+            else => try token.append(alloc, ch),
+        }
+    }
+    if (escaped) try token.append(alloc, '\\');
+    if (quote != null) return error.InvalidShellCommand;
+    if (token.items.len > 0) try args.append(alloc, try token.toOwnedSlice(alloc));
+
+    return args.toOwnedSlice(alloc);
+}
+
 // Lowercase ASCII bytes from `src` into `dest` and return the written prefix.
 pub fn lowerAscii(dest: []u8, src: []const u8) []const u8 {
     std.debug.assert(dest.len >= src.len);
@@ -297,6 +344,29 @@ test "inspect" {
     });
     defer testing.allocator.free(s2);
     try testing.expectEqualStrings("\"\\\"\\\\\\t\\e\\r\\n\\x08\\x0c\\x0b\\xff\"", s2);
+}
+
+test "shellsplit" {
+    const cases = [_]struct {
+        cmd: []const u8,
+        want: []const []const u8,
+    }{
+        .{ .cmd = "", .want = &.{} },
+        .{ .cmd = "less --RAW-CONTROL-CHARS", .want = &.{ "less", "--RAW-CONTROL-CHARS" } },
+        .{ .cmd = "less -R '+/^foo bar'", .want = &.{ "less", "-R", "+/^foo bar" } },
+        .{ .cmd = "pager\\ name \"quoted arg\"", .want = &.{ "pager name", "quoted arg" } },
+    };
+
+    for (cases) |tc| {
+        const got = try shellsplit(testing.allocator, tc.cmd);
+        defer deepFree(u8, testing.allocator, got);
+        try testing.expectEqual(tc.want.len, got.len);
+        for (tc.want, got) |want, arg| try testing.expectEqualStrings(want, arg);
+    }
+}
+
+test "shellsplit rejects unterminated quotes" {
+    try testing.expectError(error.InvalidShellCommand, shellsplit(testing.allocator, "less 'oops"));
 }
 
 test "containsIgnoreCase" {


### PR DESCRIPTION
- Fix pager startup so theme probing runs before less starts.
- Direct-exec parsed pager argv with ANSI-aware less default.
