### PR TITLE
Keep identifier ints raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ We love CSV tools and use them all the time! Here are a few that we rely on:
 - `--pager / -p` fixed
 - fix NO_COLOR=1
 - support wide east asian chars #55 (@tijptjik)
+- keep id, year and zip columns as strings
 
 #### 0.6.0 (Jun '26)
 

--- a/src/column.zig
+++ b/src/column.zig
@@ -105,7 +105,7 @@ pub const Column = struct {
         }
 
         if (floats) return .float;
-        if (ints) return .int;
+        if (ints) return if (isNotNumeric(self.name)) .string else .int;
         if (percents) return .percent;
         return .string;
     }
@@ -148,6 +148,18 @@ pub const Column = struct {
 
 // Display-oriented type inferred for a column.
 pub const ColumnType = enum { int, float, percent, string };
+
+fn isNotNumeric(name: []const u8) bool {
+    var parts = std.mem.tokenizeAny(u8, name, "_ -");
+    while (parts.next()) |part| {
+        if (std.ascii.eqlIgnoreCase(part, "id")) return true;
+        if (std.ascii.eqlIgnoreCase(part, "zip")) return true;
+        if (std.ascii.eqlIgnoreCase(part, "zipcode")) return true;
+        if (std.ascii.eqlIgnoreCase(part, "year")) return true;
+        if (std.ascii.eqlIgnoreCase(part, "yr")) return true;
+    }
+    return false;
+}
 
 //
 // testing
@@ -196,6 +208,8 @@ test "column formatting and inference cases" {
         .{ .name = "infer float", .input = "a,b,c\n1,12.5,foo\n22,3.0,barbaz\n", .index = 1, .want_type = .float, .want_width = 6, .want_fields = &.{ "12.500", "3.000" } },
         .{ .name = "infer percent", .input = "a,b\n12%,\n-3.5%,\n,\n", .index = 0, .want_type = .percent, .want_width = 5, .want_fields = &.{ "12%", "-3.5%", "" } },
         .{ .name = "infer string", .input = "a,b,c\n1,12.5,foo\n22,3.0,barbaz\n", .index = 2, .want_type = .string, .want_width = 6, .want_fields = &.{ "foo", "barbaz" } },
+        .{ .name = "infer year as string", .input = "year\n2024\n2025\n", .index = 0, .want_type = .string, .want_width = 4, .want_fields = &.{ "2024", "2025" } },
+        .{ .name = "infer zip as string", .input = "home_zip\n02139\n10001\n", .index = 0, .want_type = .string, .want_width = 8, .want_fields = &.{ "02139", "10001" } },
     };
 
     for (cases) |tc| {
@@ -243,6 +257,32 @@ test "column inference ignores blanks and scans all rows" {
 
     try testing.expectEqual(ColumnType.string, table.column(0).type);
     try testing.expectEqual(ColumnType.string, table.column(1).type);
+}
+
+test "isNotNumeric" {
+    const cases = [_]struct {
+        name: []const u8,
+        want: bool,
+    }{
+        .{ .name = "id", .want = true },
+        .{ .name = "user_id", .want = true },
+        .{ .name = "user id", .want = true },
+        .{ .name = "user-id", .want = true },
+        .{ .name = "zip", .want = true },
+        .{ .name = "zipcode", .want = true },
+        .{ .name = "year", .want = true },
+        .{ .name = "yr", .want = true },
+        .{ .name = "ZIPCODE", .want = true },
+        .{ .name = "grid", .want = false },
+        .{ .name = "zipper", .want = false },
+        .{ .name = "yearly", .want = false },
+        .{ .name = "buyer", .want = false },
+        .{ .name = "zipcodes", .want = false },
+    };
+
+    for (cases) |tc| {
+        try testing.expectEqual(tc.want, isNotNumeric(tc.name));
+    }
 }
 
 const doomicode = @import("doomicode.zig");

--- a/src/peek.zig
+++ b/src/peek.zig
@@ -284,7 +284,7 @@ test "buildStatsTable reports basic visible stats" {
 }
 
 test "buildStatsTable tolerates oversized ints in peek stats" {
-    var tt = try test_support.initTable(testing.allocator, .{}, "id\n99999999999999999999\n");
+    var tt = try test_support.initTable(testing.allocator, .{}, "count\n99999999999999999999\n");
     defer tt.deinit();
     const table = tt.table;
 
@@ -293,7 +293,7 @@ test "buildStatsTable tolerates oversized ints in peek stats" {
     const stats = try buildStatsTable(testing.allocator, table, &config);
     defer stats.deinit();
 
-    try testing.expectEqualStrings("id", stats.row(0)[0]);
+    try testing.expectEqualStrings("count", stats.row(0)[0]);
     try testing.expectEqualStrings("int", stats.row(0)[1]);
     try testing.expectEqualStrings("—", stats.row(0)[4]);
     try testing.expectEqualStrings("—", stats.row(0)[5]);

--- a/testdata/cjk.csv
+++ b/testdata/cjk.csv
@@ -1,4 +1,4 @@
-id,name,note
+row,name,note
 1,香港,city
 2,中西區,district
 3,必列者士街,street

--- a/testdata/smoke.bats
+++ b/testdata/smoke.bats
@@ -467,16 +467,16 @@ assert_output_matches() {
 }
 
 @test "renders cjk csv" {
-  run "$TENNIS_BIN" --color=off --width 40 "$REPO_ROOT/testdata/cjk.csv"
+  run "$TENNIS_BIN" --color=off --width 80 "$REPO_ROOT/testdata/cjk.csv"
   [ "$status" -eq 0 ]
-  assert_output_matches "╭────┬────────────────────┬──────────╮
-│ id │ name               │ note     │
-├────┼────────────────────┼──────────┤
-│  1 │ 香港               │ city     │
-│  2 │ 中西區             │ district │
-│  3 │ 必列者士街         │ street   │
-│  4 │ 英皇書院同學會小學 │ school   │
-╰────┴────────────────────┴──────────╯"
+  assert_output_matches "╭─────┬────────────────────┬──────────╮
+│ row │ name               │ note     │
+├─────┼────────────────────┼──────────┤
+│   1 │ 香港               │ city     │
+│   2 │ 中西區             │ district │
+│   3 │ 必列者士街         │ street   │
+│   4 │ 英皇書院同學會小學 │ school   │
+╰─────┴────────────────────┴──────────╯"
 }
 
 @test "renders formatted floats and ints" {


### PR DESCRIPTION
- Keep id, year and zip integer columns as strings.
